### PR TITLE
Update API url var names to current

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,12 @@ If you've been onboarded, or have worked with a Node-based project that uses NPM
 
 ### Base Requirements
 A .env file is required in the root, with these vars defined:
+
+```
 SKIP_PREFLIGHT_CHECK=true
-REACT_APP_API_URL=
+REACT_APP_MERMAID_API_URL=
+REACT_APP_SUMMARY_API_URL=
+```
 
 #### Node
 


### PR DESCRIPTION
Updated the README to show the current API vars used within the app. Not sure if instead of showing the empty values though we should at least put the prod values to be something like this:

```
SKIP_PREFLIGHT_CHECK=true
REACT_APP_MERMAID_API_URL=https://api.datamermaid.org
REACT_APP_SUMMARY_API_URL=https://summary-api.datamermaid.org
```

I noticed that even the dev Dashboard site (https://dev-dashboard.datamermaid.org/) is also calling the production APIs (for both _api_ and _summary-api_), which maybe makes sense since this application is read-only?

For now, I left the two API URLs empty in the docs, but at least the proper var names are mentioned. Let me know if I should change it to show the values for prod (as seen above) or if there are non-prod APIs to reference instead.