### PR TITLE
Consolidate theme color usage in components

### DIFF
--- a/src/components/BarChart.js
+++ b/src/components/BarChart.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { VictoryBar, VictoryChart, VictoryAxis, VictoryTooltip, VictoryLine } from 'victory';
+import { color } from '../constants/theme';
 
 import PropTypes from 'prop-types';
 
@@ -50,7 +51,7 @@ const BarChart = ({ chartContent }) => {
             cornerRadius={4}
             pointerLength={7}
             flyoutStyle={{
-              stroke: '#004C76',
+              stroke: color.mermaidDarkBlue,
               strokeWidth: 2,
               fill: 'skyblue',
               opacity: 0.75
@@ -69,7 +70,7 @@ const BarChart = ({ chartContent }) => {
                 return [
                   {
                     target: 'data',
-                    mutation: () => ({ style: { fill: '#004C76' } })
+                    mutation: () => ({ style: { fill: color.mermaidDarkBlue } })
                   },
                   {
                     target: 'labels',
@@ -95,8 +96,14 @@ const BarChart = ({ chartContent }) => {
         x="x"
         y="y"
       />
-      <VictoryLine x={() => 11} style={{ data: { stroke: '#004C76', strokeDasharray: [1, 2] } }} />
-      <VictoryLine x={() => 31} style={{ data: { stroke: '#004C76', strokeDasharray: [1, 2] } }} />
+      <VictoryLine
+        x={() => 11}
+        style={{ data: { stroke: color.mermaidDarkBlue, strokeDasharray: [1, 2] } }}
+      />
+      <VictoryLine
+        x={() => 31}
+        style={{ data: { stroke: color.mermaidDarkBlue, strokeDasharray: [1, 2] } }}
+      />
     </VictoryChart>
   );
 };

--- a/src/components/BottomSummaryPanel.js
+++ b/src/components/BottomSummaryPanel.js
@@ -18,6 +18,7 @@ import MetricCards from './MetricCardsContainer';
 import InformationCard from './InformationCard';
 import SiteDetail from './SiteDetail';
 import { histogram as histogramSummary } from '../constants/summary-information';
+import { color } from '../constants/theme';
 
 const bottomPanelStyleProperties = makeStyles(theme => ({
   selectedSiteProperty: {
@@ -66,7 +67,7 @@ const BottomPanelContainer = styled('div')`
     props.open &&
     css`
       top: 49px;
-      background-color: #f4f4f4;
+      background-color: ${color.mermaidWhiteGray};
       overflow-x: hidden;
       overflow-y: overlay;
     `}

--- a/src/components/DrawerDashBoard.js
+++ b/src/components/DrawerDashBoard.js
@@ -16,7 +16,7 @@ import { histogramContext } from '../context/histogramContext';
 import MetricCards from './MetricCardsContainer';
 import InformationCard from './InformationCard';
 import SiteDetail from './SiteDetail';
-import { theme } from '../constants/theme';
+import { color, theme } from '../constants/theme';
 import { ButtonStyle } from '../styles/MermaidStyledComponents';
 import {
   summary,
@@ -35,7 +35,7 @@ const drawerStyleProperties = makeStyles(theme => ({
     flexShrink: 0
   },
   drawerPaper: {
-    backgroundColor: '#F4F4F4',
+    backgroundColor: color.mermaidWhiteGray,
     width: drawerWidth,
     top: 49,
     [theme.breakpoints.down('sm')]: {

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -12,11 +12,12 @@ import { MenuLink } from '../styles/MermaidStyledComponents';
 import HeaderMenu from './HeaderMenu';
 import IntroModal from './IntroModal';
 import headerContent from '../constants/header-content';
+import { color } from '../constants/theme';
 
 const headerStyles = makeStyles(theme => ({
   appBarProperty: {
     position: 'fixed',
-    background: '#2C3742',
+    background: color.mermaidDark,
     height: 49,
     justifyContent: 'center'
   },

--- a/src/components/IntroModal.js
+++ b/src/components/IntroModal.js
@@ -12,11 +12,12 @@ import Box from '@material-ui/core/Box';
 
 import { DialogText } from '../styles/MermaidStyledComponents';
 import ModalContent from './ModalContent';
+import { color } from '../constants/theme';
 
 const InlineButtonImage = styled('span')`
   color: white;
   display: inline-flex;
-  background: #004c76;
+  background: ${color.mermaidDarkBlue};
   align-items: center;
   justify-content: center;
   padding: 2px 6px 4px 6px;

--- a/src/components/LeafletMapControl.js
+++ b/src/components/LeafletMapControl.js
@@ -16,7 +16,7 @@ import Typography from '@material-ui/core/Typography';
 import Fade from '@material-ui/core/Fade';
 
 import { ButtonStyle } from '../styles/MermaidStyledComponents';
-import { theme } from '../constants/theme';
+import { color, theme } from '../constants/theme';
 
 import PropTypes from 'prop-types';
 
@@ -34,7 +34,7 @@ const mapControlStyleProperty = makeStyles(theme => ({
     borderRadius: '0 0 4px 4px',
     fontSize: '80%',
     zIndex: 1000,
-    backgroundColor: '#F4F4F4'
+    backgroundColor: color.mermaidWhiteGray
   },
   filterIconWrapperProperty: {
     position: 'fixed',

--- a/src/components/LiveCoralCoverModal.js
+++ b/src/components/LiveCoralCoverModal.js
@@ -10,12 +10,13 @@ import MuiDialogActions from '@material-ui/core/DialogActions';
 
 import { DialogText } from '../styles/MermaidStyledComponents';
 import ModalContent from './ModalContent';
+import { color } from '../constants/theme';
 
 const LiveCoralCoverModal = ({ open, modalToggleHandler }) => {
   const clickToViewModal = (
     <Tooltip title="More Information & References" placement="right">
       <IconButton onClick={modalToggleHandler}>
-        <HelpIcon style={{ color: '#004C76', fontSize: '30px' }} />
+        <HelpIcon style={{ color: color.mermaidDarkBlue, fontSize: '30px' }} />
       </IconButton>
     </Tooltip>
   );

--- a/src/components/MetricCard.js
+++ b/src/components/MetricCard.js
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import numberWithCommas from '../lib/number-format';
+import { color } from '../constants/theme';
 
 import { makeStyles } from '@material-ui/core/styles';
 import styled, { css } from 'styled-components/macro';
@@ -33,7 +34,7 @@ const TitleBoxStyle = styled.div`
 `;
 
 const ContentBoxStyle = styled.div`
-  color: #004c76;
+  color: ${color.mermaidDarkBlue};
   padding: ${props => props.bottomPanelOpen && '30px 0px 0px 0px'};
   font-size: ${props => (props.bottomPanelOpen ? '35px' : '32px')};
   @media (min-width: 960px) {

--- a/src/constants/theme.js
+++ b/src/constants/theme.js
@@ -1,4 +1,4 @@
-const color = {
+export const color = {
   mermaidDark: '#2C3742',
   mermaidWhite: 'white',
   mermaidBlue: '#337ab7',


### PR DESCRIPTION
I have exported the theme colors and referenced them by name throughout the components to avoid repeating the hexa codes. This should make future color refactoring easier and prevent inconsistencies.